### PR TITLE
Fixed favicon fails to load on Chat.Meta domain

### DIFF
--- a/injected_script.js
+++ b/injected_script.js
@@ -15,6 +15,9 @@ defaultFaviconHref = defaultFaviconHref.replace(/^https?:/, '');
 // now force the cdn
 defaultFaviconHref = defaultFaviconHref.replace(/^\/\/[^\/]*\/(content\/)?/, '//cdn.sstatic.net/');
 
+// some sites have /Content in the path which does not match the cdn... remove that
+defaultFaviconHref = defaultFaviconHref.replace(/\/Content/i, '');
+
 // aaand use https... because we're good people
 defaultFaviconHref = 'https:' + defaultFaviconHref;
 

--- a/injected_script.js
+++ b/injected_script.js
@@ -13,10 +13,7 @@ let defaultFaviconHref = favicon.href;
 defaultFaviconHref = defaultFaviconHref.replace(/^https?:/, '');
 
 // now force the cdn
-defaultFaviconHref = defaultFaviconHref.replace(/^\/\/[^\/]*\/(content\/)?/, '//cdn.sstatic.net/');
-
-// some sites have /Content in the path which does not match the cdn... remove that
-defaultFaviconHref = defaultFaviconHref.replace(/\/Content/i, '');
+defaultFaviconHref = defaultFaviconHref.replace(/^\/\/[^\/]*\/(content\/)?/i, '//cdn.sstatic.net/');
 
 // aaand use https... because we're good people
 defaultFaviconHref = 'https:' + defaultFaviconHref;


### PR DESCRIPTION
Fixes #2 by removing `/Content` in the path to the CDN.